### PR TITLE
Implement path tiny

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,10 +6,10 @@ requires 'App::Cmd::Plugin::Prompt'  => '0';
 requires 'Perl::Critic'              => '0';
 requires 'Git::Repository'           => '0';
 requires 'JSON::XS'                  => '0';
+requires 'Path::Tiny'                => '0';
 
 # Core
 requires 'FindBin'                   => '0';
-requires 'Path::Class'               => '0';
 requires 'Scalar::Util'              => '0';
 requires 'Carp'                      => '0';
 requires 'File::HomeDir'             => '0';

--- a/lib/App/Critique/Command/process.pm
+++ b/lib/App/Critique/Command/process.pm
@@ -3,6 +3,8 @@ package App::Critique::Command::process;
 use strict;
 use warnings;
 
+use Path::Tiny ();
+
 use App::Critique::Session;
 
 use App::Critique -command;
@@ -172,7 +174,7 @@ sub display_violation {
     info('  policy   : %s'           => $violation->policy);
     info('  severity : %d'           => $violation->severity);
     info('  location : %s @ <%d:%d>' => (
-        Path::Class::File->new( $violation->filename )->relative( $session->git_work_tree ),
+        Path::Tiny::path( $violation->filename )->relative( $session->git_work_tree ),
          $violation->line_number,
          $violation->column_number
     ));

--- a/lib/App/Critique/Command/remove.pm
+++ b/lib/App/Critique/Command/remove.pm
@@ -63,7 +63,7 @@ sub execute {
         }
         else {
             info('Attempting to remove empty branch directory ...');
-            if ( $branch->rmtree ) {
+            if ( $branch->remove_tree ) {
                 info('Successfully removed empty branch directory (%s).', $branch);
             }
             else {
@@ -88,7 +88,7 @@ sub execute {
         }
         else {
             info('Attempting to remove empty repo directory ...');
-            if ( $repo->rmtree ) {
+            if ( $repo->remove_tree ) {
                 info('Successfully removed empty repo directory (%s).', $repo);
             }
             else {

--- a/lib/App/Critique/Session.pm
+++ b/lib/App/Critique/Session.pm
@@ -7,7 +7,6 @@ use Scalar::Util        ();
 use Carp                ();
 
 use File::HomeDir       ();
-use File::Spec          ();
 use Path::Tiny          ();
 use JSON::XS            ();
 
@@ -223,7 +222,7 @@ sub _generate_critique_file_path {
 sub _initialize_git_repo {
     my ($class, %args) = @_;
 
-    my $git = Git::Repository->new( work_tree => $args{git_work_tree} || File::Spec->curdir );
+    my $git = Git::Repository->new( work_tree => $args{git_work_tree} || Path::Tiny->cwd );
 
     # auto-discover the current git branch
     my ($git_branch) = map /^\*\s(.*)$/, grep /^\*/, $git->run('branch');

--- a/lib/App/Critique/Session/File.pm
+++ b/lib/App/Critique/Session/File.pm
@@ -6,7 +6,6 @@ use warnings;
 use Scalar::Util        ();
 use Carp                ();
 
-use File::Spec          ();
 use Path::Tiny          ();
 
 sub new {

--- a/lib/App/Critique/Session/File.pm
+++ b/lib/App/Critique/Session/File.pm
@@ -7,7 +7,7 @@ use Scalar::Util        ();
 use Carp                ();
 
 use File::Spec          ();
-use Path::Class         ();
+use Path::Tiny          ();
 
 sub new {
     my ($class, %args) = @_;
@@ -20,9 +20,9 @@ sub new {
     (-e $path && -f $path)
         || Carp::confess('The `path` argument must be a valid file, not: ' . $path);
 
-    $path = Path::Class::File->new( $path )
+    $path = Path::Tiny::path( $path )
         unless Scalar::Util::blessed( $path )
-            && $path->isa('Path::Class::File');
+            && $path->isa('Path::Tiny');
 
     return bless {
         path => $path,


### PR DESCRIPTION
Watch your YAPC::NA talk, saw this #3 and did it, hope it helps with the brain switch.

Mostly it was a quick switch from P::Class to P::Tiny, same for F::Spec.

In traverse_filesystem I did a variable change from $dir to $path, as the variables contents a path and not just a dir.

To test I ran through a complete workflow with a little (300+ files with a few issues) repo, an nothing broke.
