### PR TITLE
Added local directory to the things to skip in when collecting files.

### DIFF
--- a/lib/App/Critique/Command/collect.pm
+++ b/lib/App/Critique/Command/collect.pm
@@ -87,7 +87,7 @@ sub execute {
 }
 
 
-my %SKIP = map { ($_ => 1) } qw[  CVS RCS .svn _darcs {arch} .bzr .cdv .git .hg .pc _build blib  ];
+my %SKIP = map { ($_ => 1) } qw[  CVS RCS .svn _darcs {arch} .bzr .cdv .git .hg .pc _build blib local ];
 
 sub traverse_filesystem {
     my ($path, $filter, $v) = @_;


### PR DESCRIPTION
I use local::lib in my projects, this saved having to add a lib,t,bin ... directories separately.

The only issue i see with this is if i have lib/ACoolApp/Servers/local/Hosts (yes its a lower case l, but stranger things have happened), however this is true for any of the values in %SKIP. 