### PR TITLE
Moved the file filters into their own plugin.

### DIFF
--- a/lib/App/Critique.pm
+++ b/lib/App/Critique.pm
@@ -11,7 +11,8 @@ our %CONFIG;
 use App::Cmd::Setup -app => {
     plugins => [
         'Prompt',
-        '=App::Critique::Plugin::UI'
+        '=App::Critique::Plugin::UI',
+        '=App::Critique::Plugin::FileFilter'
     ]
 };
 

--- a/lib/App/Critique/Command/collect.pm
+++ b/lib/App/Critique/Command/collect.pm
@@ -41,9 +41,7 @@ sub execute {
         : $session->git_work_tree;
 
     my $filter;
-    if ( my $f = $opt->filter ) {
-        $filter = file_filter($opt,'file_filter_regex');
-    }
+    if ( $opt->filter ) { $filter = file_filter_regex(%$opt) }
 
     my @all;
     traverse_filesystem(

--- a/lib/App/Critique/Command/collect.pm
+++ b/lib/App/Critique/Command/collect.pm
@@ -42,14 +42,7 @@ sub execute {
 
     my $filter;
     if ( my $f = $opt->filter ) {
-        if ( ref $f eq 'CODE' ) {
-            $filter = $f;
-        }
-        else {
-            $filter = $opt->invert
-                ? sub { $_[0]->stringify !~ /$f/ }
-                : sub { $_[0]->stringify =~ /$f/ };
-        }
+        $filter = file_filter($opt,'file_filter_regex');
     }
 
     my @all;

--- a/lib/App/Critique/Command/prune.pm
+++ b/lib/App/Critique/Command/prune.pm
@@ -48,34 +48,10 @@ sub execute {
     my $filter;
 
     if ( my $f = $opt->filter ) {
-        $filter =  sub {
-            my $path     = $_[0]->path->stringify;
-            my $is_match = $opt->invert ? $path !~ /$f/ : $path =~ /$f/;
-            if ( $opt->verbose ) {
-                if ( $is_match ) {
-                    info('Matched, keeping file (%s) ', $path);
-                }
-                else {
-                    info('Not matched, pruning file (%s) ', $path);
-                }
-            }
-            return !! $is_match;
-        };
+        $filter = file_filter_regex($opt);
     }
     elsif ( $opt->no_violation ) {
-        $filter = sub {
-            my $path           = $_[0]->path->stringify;
-            my $num_violations = scalar $session->perl_critic->critique( $path );
-            if ( $opt->verbose ) {
-                if ( $num_violations ) {
-                    info('Found %d violation(s), keeping file (%s) ', $num_violations, $path);
-                }
-                else {
-                    info('Found no violation, pruning file (%s) ', $path);
-                }
-            }
-            return !! $num_violations;
-        };
+        $filter = file_filter_no_violations($opt,$session);
     }
 
     my @old_files = $session->tracked_files;

--- a/lib/App/Critique/Command/prune.pm
+++ b/lib/App/Critique/Command/prune.pm
@@ -47,11 +47,11 @@ sub execute {
 
     my $filter;
 
-    if ( my $f = $opt->filter ) {
-        $filter = file_filter_regex($opt);
+    if ( $opt->filter ) {
+        $filter = file_filter_regex(%$opt)
     }
     elsif ( $opt->no_violation ) {
-        $filter = file_filter_no_violations($opt,$session);
+        $filter = file_filter_no_violations( %$opt, session => $session )
     }
 
     my @old_files = $session->tracked_files;

--- a/lib/App/Critique/Plugin/FileFilter.pm
+++ b/lib/App/Critique/Plugin/FileFilter.pm
@@ -1,0 +1,139 @@
+package App::Critique::Plugin::FileFilter;
+
+use strict;
+use warnings;
+
+our $VERSION   = '0.01';
+our $AUTHORITY = 'cpan:STEVAN';
+
+use App::Critique -ignore;
+
+use App::Cmd::Setup -plugin => {
+    exports => [
+        qw[
+          file_filter_no_violations
+          file_filter_regex
+          file_filter
+          ]
+    ]
+};
+
+sub file_filter_no_violations {
+    my ( $plugin, $cmd, @args ) = @_;
+    _no_violations(@args);
+}
+sub file_filter_regex { my ( $plugin, $cmd, @args ) = @_; _regex(@args) }
+sub file_filter       { my ( $plugin, $cmd, @args ) = @_; _filter(@args) }
+
+sub _no_violations {
+    my ( $opt, $session ) = @_;
+    die 'no_violation requires a options' unless $opt;
+    die 'no_violation requires a App::Critique::Session'
+      unless ref($session) eq 'App::Critique::Session';
+    return sub {
+        my $path           = $_[0]->path->stringify;
+        my $num_violations = scalar $session->perl_critic->critique($path);
+        if ( $opt->verbose ) {
+            if ($num_violations) {
+                App::Critique::Plugin::UI::info( 'FileFilters', 'no_violation',
+                    'Found %d violation(s), keeping file (%s) ',
+                    $num_violations, $path );
+            }
+            else {
+                App::Critique::Plugin::UI::info( 'FileFilters', 'no_violation',
+                    'Found no violation, pruning file (%s) ', $path );
+            }
+        }
+        return !!$num_violations;
+    };
+}
+
+sub _regex {
+    my ($opt) = @_;
+    die 'regex_filter requires a options' unless $opt;
+    my $f = $opt->filter;
+    return sub {
+        return unless $f;
+        my $path = $_[0]->path->stringify;
+        my $is_match = $opt->invert ? $path !~ /$f/ : $path =~ /$f/;
+        if ( $opt->verbose ) {
+            if ($is_match) {
+                App::Critique::Plugin::UI::info( 'FileFilters', 'regex',
+                    'Matched, keeping file (%s) ', $path );
+            }
+            else {
+                App::Critique::Plugin::UI::info( 'FileFilters', 'regex',
+                    'Not matched, pruning file (%s) ', $path );
+            }
+        }
+        return !!$is_match;
+    };
+}
+
+sub _filter {
+    my ( $opt, $default, @args ) = @_;
+    die 'filter requires a options'                unless $opt;
+    die 'filter requires default fall back filter' unless $default;
+    my $filter;
+    if ( my $f = $opt->filter ) {
+        if ( ref $f eq 'CODE' ) {
+            $filter = $f;
+        }
+        else {
+            no strict 'refs';
+            $filter = &{$default}( $opt, @args );
+        }
+    }
+    return $filter;
+}
+
+1;
+
+__END__
+
+# ABSTRACT: Prebuilt reusable filters
+
+=pod
+
+=head1 NAME
+
+App::Critique::Util::FileFilters - Collection of file filters
+
+=head1 DESCRIPTION
+
+This utility module defines some filters to enable code reuse.
+
+=head1 Subroutines
+
+=head2 no_violation
+
+    no_violation($opt, $session)
+
+$session must be a App::Critique::Session.
+
+
+
+=head2 regex_filter
+
+    regex_filter($opt)
+
+Uses the $opt->filter to build a regex to filter the files.
+
+If $opt->invert is present the filter is inverted.
+
+=head2 filter
+
+    filter($opt, $default)
+
+if $opt contains a filter, and is not a coderef, then fall back to the specified
+default, which could be any subroutine within this module.
+=cut
+
+
+1;
+
+__END__
+
+=pod
+
+=cut


### PR DESCRIPTION
The Plugin version of #8. Its pretty much a carbon copy with just a few things moved about.

Except for a tinnie tiny bug I noticed with respect to `_filter`, if the default or fallback subroutine requires more than just $opt to be passed in, like no-violations, then it would have failed. Lucky it was a noisy fail, but a fail none the less.

I am starting to get the feeling I want to use named params when dealing with the file filters, as it would remove some ambiguity on what param goes where. 