### PR TITLE
Fixed option ordering so implied options comes before the option it i…

### DIFF
--- a/lib/App/Critique/Command.pm
+++ b/lib/App/Critique/Command.pm
@@ -15,8 +15,8 @@ sub opt_spec {
     return (
         [ 'git-work-tree=s', 'git working tree, defaults to current working directory', { default => Path::Tiny->cwd } ],
         [],
-        [ 'verbose|v',       'display additional information', { default => $App::Critique::CONFIG{'VERBOSE'}                     } ],
         [ 'debug|d',         'display debugging information',  { default => $App::Critique::CONFIG{'DEBUG'}, implies => 'verbose' } ],
+        [ 'verbose|v',       'display additional information', { default => $App::Critique::CONFIG{'VERBOSE'}                     } ],
     );
 }
 


### PR DESCRIPTION
…mplies.

Currently when with the debug flag I get

perl -Mlocal::lib=../p5-App-Critique/local  ../p5-App-Critique/bin/critique init --force -d
The 'debug' parameter ("1") to "eval" did not pass the 'debug implies verbose=1' callback: option
specification for debug implies that verbose should be set to '1', but it is '0' already.
