### PR TITLE
Toggle the diff to be coloured.

### DIFF
--- a/lib/App/Critique/Command/process.pm
+++ b/lib/App/Critique/Command/process.pm
@@ -215,8 +215,7 @@ EDIT:
         info(HR_DARK);
         info('Changes detected, generating diff.');
         info(HR_LIGHT);
-        info('%s', join "\n" => $git->diff);
-
+        info('%s', join "\n" => $git->RUN('diff',{ 'color' => $App::Critique::CONFIG{COLOR} }));
         my $policy_name = $violation->policy;
         $policy_name =~ s/^Perl\:\:Critic\:\:Policy\:\://;
 


### PR DESCRIPTION
as described in #21, with only one change, I have used `$App::Critique::CONFIG{COLOR}` which is more correct.