### PR TITLE
Fix uninitialized variables when GetTerminalSize fails

### DIFF
--- a/lib/App/Critique/Plugin/UI.pm
+++ b/lib/App/Critique/Plugin/UI.pm
@@ -9,10 +9,18 @@ our $AUTHORITY = 'cpan:STEVAN';
 use Term::ReadKey  ();
 use Number::Format ();
 
-use constant TERM_WIDTH => eval { local $SIG{__WARN__} = sub {''}; (Term::ReadKey::GetTerminalSize())[0] // 80 };
-use constant HR_ERROR   => ('== ERROR '.('=' x (TERM_WIDTH - 9)));
-use constant HR_DARK    => ('=' x TERM_WIDTH);
-use constant HR_LIGHT   => ('-' x TERM_WIDTH);
+sub TERM_WIDTH () {
+    my $size = eval {
+        local $SIG{__WARN__} = sub {''};
+        ( Term::ReadKey::GetTerminalSize() )[0];
+    } || 80;
+
+    return $size;
+}
+
+use constant HR_ERROR => ( '== ERROR ' . ( '=' x ( TERM_WIDTH - 9 ) ) );
+use constant HR_DARK  => ( '=' x TERM_WIDTH );
+use constant HR_LIGHT => ( '-' x TERM_WIDTH );
 
 use App::Critique -ignore;
 


### PR DESCRIPTION
When [Term::ReadKey](https://metacpan.org/pod/Term::ReadKey)::GetTerminalSize() fails, the eval fails and it doesn't reach the `// 80` line. This can be wrapped again but it's easier to just stick this into an old-school constant definition.