### PR TITLE
Improve editor command line arguments

### DIFF
--- a/lib/App/Critique/Command/process.pm
+++ b/lib/App/Critique/Command/process.pm
@@ -11,6 +11,7 @@ use List::Util      ();
 use Term::ANSIColor ':constants';
 
 use App::Critique::Session;
+use App::Critique::Utils ();
 
 use App::Critique -command;
 
@@ -259,14 +260,15 @@ sub edit_violation {
     my $policy       = $violation->policy;
     my $rewriter     = $policy->can('rewriter') ? $policy->rewriter( $violation ) : undef;
 
-    my $cmd_fmt  = $App::Critique::CONFIG{EDITOR};
     my @cmd_args = (
         $rel_filename,
         $violation->line_number,
         $violation->column_number
     );
 
-    my $cmd = sprintf $cmd_fmt => @cmd_args;
+    my $cmd = App::Critique::Utils::editor_cmd(
+        $App::Critique::CONFIG{EDITOR}, @cmd_args,
+    ) || join ' ', $App::Critique::CONFIG{EDITOR}, $rel_filename;
 
 EDIT:
     if ( $rewriter && $rewriter->can_rewrite ) {

--- a/lib/App/Critique/Utils.pm
+++ b/lib/App/Critique/Utils.pm
@@ -1,0 +1,41 @@
+package App::Critique::Utils;
+# ABSTRACT: Set of utilities for App::Critique
+
+use strict;
+use warnings;
+use parent 'Exporter';
+use Carp ();
+
+our @EXPORT_OK = qw< editor_cmd >;
+
+our %EDITOR_FMT = (
+    'vim'         => '"+call cursor(%line%, %column%)" %filename%',
+    'emacs'       => '+%line%:%column% %filename%',
+    'sublimetext' => '%filename%:%line%:%column%',
+);
+
+our %EDITOR_ALIASES = (
+    'subl' => 'sublimetext',
+);
+
+sub editor_cmd {
+    my ( $editor, $filename, $line, $column ) = @_;
+
+    @_ == 4
+        or Carp::croak('editor_cmd( $editor, $filename, $line, $column )');
+
+    $editor //= '';
+
+    my $fmt = $EDITOR_FMT{$editor}
+        || $EDITOR_FMT{ $EDITOR_ALIASES{$editor} // '' }
+        or return;
+
+    $fmt =~ s/%line%/$line/xmsg;
+    $fmt =~ s/%column%/$column/xmsg;
+    $fmt =~ s/%filename%/$filename/xmsg;
+
+    return "$editor $fmt";
+}
+
+
+1;

--- a/t/Utils/editor_cmd.t
+++ b/t/Utils/editor_cmd.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More 'tests' => 5;
+use App::Critique::Utils qw< editor_cmd >;
+
+is(
+    editor_cmd( 'vim', 'file.pl', '10', '20' ),
+    'vim "+call cursor(10, 20)" file.pl',
+    'vim returns correct command line',
+);
+
+is(
+    editor_cmd( 'emacs', 'file.pl', '10', '20' ),
+    'emacs +10:20 file.pl',
+    'emacs returns correct command line',
+);
+
+my $subl = 'file.pl:10:20';
+is(
+    editor_cmd( 'sublimetext', 'file.pl', '10', '20' ),
+    "sublimetext $subl",
+    'sublimetext returns correct command line',
+);
+
+is(
+    editor_cmd( 'subl', 'file.pl', '10', '20' ),
+    "subl $subl",
+    'subl is the same as sublimetext',
+);
+
+is(
+    editor_cmd( 'void', 'file.pl', '10', '20' ),
+    undef,
+    'No such editor',
+);


### PR DESCRIPTION
Instead of assuming the command line arguments are fit for opening in a particular line and column, we now translate based on the command line.

The only proper way would be to include information on how each editor needs its arguments.

If the editor is unknown, we simply use the editor parameter with the filename, which is the only likely thing to at least work:

    $ENV{EDITOR} file.pl

If we were to try to also introduce the line and column numbers, it is more likely to fail than succeed because each editor parses command line differently.

A problem that still needs to be addressed is the usage of `$App::Critique::CONFIG{CRITIQUE_EDITOR}` as the same value as `$App::Critique::COFNIG{EDITOR}` as the same value as `$ENV{EDITOR}`.

These are different and should not be mixed together. It would likely require some more subtle logic in Critique.pm, hopefully removing the `BEGIN {}` block at the process. :)

This small bit includes a test. It is not numbered because I don't see the point of numbering tests.