### PR TITLE
Use File's critique method in process

### DIFF
--- a/lib/App/Critique/Command/process.pm
+++ b/lib/App/Critique/Command/process.pm
@@ -106,7 +106,7 @@ MAIN:
         # decide if they want to carry on
         my @violations;
         eval {
-            @violations = $self->discover_violations( $session, $file, $opt );
+            @violations = $file->critique( $session );
             1;
         } or do {
             info(HR_ERROR);
@@ -190,14 +190,6 @@ MAIN:
 
     }
 
-}
-
-sub discover_violations {
-    my ($self, $session, $file, $opt) = @_;
-
-    my @violations = $session->perl_critic->critique( $file->path->stringify );
-
-    return @violations;
 }
 
 


### PR DESCRIPTION
This is a bugfix for previous PR for file types support.
Does not make a difference for perl5 type, but makes one if there's a different critique() method.